### PR TITLE
Compile on Uno R4

### DIFF
--- a/src/ACAN2517.cpp
+++ b/src/ACAN2517.cpp
@@ -7,6 +7,11 @@
 
 #include <ACAN2517.h>
 
+// The Uno R4 does not define NOT_AN_INTERRUPT
+#ifndef NOT_AN_INTERRUPT
+#define NOT_AN_INTERRUPT -1
+#endif
+
 //------------------------------------------------------------------------------
 // Note about ESP32
 //------------------------------------------------------------------------------


### PR DESCRIPTION
When using the Uno R4, the macro `NOT_AN_INTERRUPT` is not defined.  Define it to a sane value so that the library will compile.